### PR TITLE
Properly get the Acceleration and Tilt information from the chip

### DIFF
--- a/MMA7660.cpp
+++ b/MMA7660.cpp
@@ -30,105 +30,102 @@
 
 #include <Wire.h>
 #include "MMA7660.h"
+
 /*Function: Write a byte to the register of the MMA7660*/
-void MMA7660::write(uint8_t _register, uint8_t _data)
-{
-    Wire.begin();
-    Wire.beginTransmission(MMA7660_ADDR);
-    Wire.write(_register);
-    Wire.write(_data);
-    Wire.endTransmission();
+void MMA7660::write(uint8_t _register, uint8_t _data) {
+  Wire.begin();
+  Wire.beginTransmission(MMA7660_ADDR);
+  Wire.write(_register);
+  Wire.write(_data);
+  Wire.endTransmission();
 }
+
 /*Function: Read a byte from the regitster of the MMA7660*/
-uint8_t MMA7660::read(uint8_t _register)
-{
-    uint8_t data_read;
-    Wire.begin();
-    Wire.beginTransmission(MMA7660_ADDR);
-    Wire.write(_register);
-    Wire.endTransmission();
-    Wire.beginTransmission(MMA7660_ADDR);
-    Wire.requestFrom(MMA7660_ADDR,1);
-    while(Wire.available())
-    {
-        data_read = Wire.read();
-    }
-    Wire.endTransmission();
-    return data_read;
+uint8_t MMA7660::read(uint8_t _register) {
+  uint8_t data_read;
+  Wire.begin();
+  Wire.beginTransmission(MMA7660_ADDR);
+  Wire.write(_register);
+  Wire.endTransmission();
+  Wire.beginTransmission(MMA7660_ADDR);
+  Wire.requestFrom(MMA7660_ADDR,1);
+  while(Wire.available())
+  {
+    data_read = Wire.read();
+  }
+  Wire.endTransmission();
+  return data_read;
 }
 
 void MMA7660::init()
 {
-    setMode(MMA7660_STAND_BY);
-    setSampleRate(AUTO_SLEEP_32);
-    write(MMA7660_INTSU, 0xE0);
-    write(MMA7660_PDET, 0xE0);
-    setMode(MMA7660_ACTIVE);
+  setMode(MMA7660_STAND_BY);
+  setSampleRate(AUTO_SLEEP_32);
+  setMode(MMA7660_ACTIVE);
 }
-void MMA7660::setMode(uint8_t mode)
+
+void MMA7660::init(uint8_t interrupts)
 {
-    write(MMA7660_MODE,mode);
+  setMode(MMA7660_STAND_BY);
+  setSampleRate(AUTO_SLEEP_32);
+  write(MMA7660_INTSU, interrupts);
+  setMode(MMA7660_ACTIVE);
 }
-void MMA7660::setSampleRate(uint8_t rate)
-{
-    write(MMA7660_SR,rate);
+void MMA7660::setMode(uint8_t mode) {
+  write(MMA7660_MODE,mode);
+}
+void MMA7660::setSampleRate(uint8_t rate) {
+  write(MMA7660_SR,rate);
 }
 /*Function: Get the contents of the registers in the MMA7660*/
 /*          so as to calculate the acceleration.            */
-void MMA7660::getXYZ(int8_t *x,int8_t *y,int8_t *z)
-{
-    unsigned char val[3];
-    int count = 0;
-    val[0] = val[1] = val[2] = 64;
-    while(Wire.available() > 0)
-        Wire.read();
-    Wire.requestFrom(MMA7660_ADDR,3);
-    while(Wire.available())
-    {
-        if(count < 3)
-        {
-            while ( val[count] > 0x3F )  // reload the damn thing it is bad
-            {
-              val[count] = Wire.read();
-            }
-        }
-        count++;
-    }
-    *x = ((char)(val[0]<<2))/4;
-    *y = ((char)(val[1]<<2))/4;
-    *z = ((char)(val[2]<<2))/4;
-}
-
-void MMA7660::getData()
-{
-  unsigned char val[11] = {0};
+void MMA7660::getXYZ(int8_t *x, int8_t *y, int8_t *z) {
+  unsigned char val[3];
   int count = 0;
 
-  while(Wire.available() > 0)
-      Wire.read();
-  Wire.requestFrom(MMA7660_ADDR,11);
-  while(Wire.available())
-  {
-      if(count < 11)
-      {
+  while(Wire.available() > 0) {
+    Wire.read();
+  }
+
+  Wire.requestFrom(MMA7660_ADDR, 3);
+  while(Wire.available()) {
+    if (count < 3) {
+      while (val[count] > 0x3F) {  // reload the damn thing it is bad
         val[count] = Wire.read();
       }
-      count++;
+    }
+    count++;
   }
-
-  for (count = 0; count < 11; count++) {
-    Serial.printf("0x%02X val: 0x%02X\n", count, val[count]);
-  }
-
-  Serial.printf("Shake sensor: 0x%02X\n", val[3] & 0x80);
-  Serial.printf("Tap sensor: 0x%02X\n", val[3] & 0x20);
+  *x = (((char)(val[0] << 2)) / -4) - 30;
+  *y = (((char)(val[1] << 2)) / -4) - 30;
+  *z = (((char)(val[2] << 2)) / -4) - 30;
 }
 
-void MMA7660::getAcceleration(float *ax,float *ay,float *az)
-{
-    int8_t x,y,z;
-    getXYZ(&x,&y,&z);
-    *ax = x/21.00;
-    *ay = y/21.00;
-    *az = z/21.00;
+void MMA7660::getAllData(MMA7760_DATA *data) {
+  int count = 0;
+  uint8_t val[11] = {0};
+
+  while (Wire.available() > 0) {
+    Wire.read();
+  }
+
+  Wire.requestFrom(MMA7660_ADDR, 11);
+  while (Wire.available()) {
+    if (count < 11) {
+      val[count] = Wire.read();
+    }
+    count++;
+  }
+
+  data->X = val[0];
+  data->Y = val[1];
+  data->Z = val[2];
+  data->TILT = val[3];
+  data->SRST = val[4];
+  data->SPCNT = val[5];
+  data->INTSU = val[6];
+  data->MODE = val[7];
+  data->SR = val[8];
+  data->PDET = val[9];
+  data->PD = val[10];
 }

--- a/MMA7660.cpp
+++ b/MMA7660.cpp
@@ -3,7 +3,7 @@
  * Library for accelerometer_MMA7760
  *
  * Copyright (c) 2013 seeed technology inc.
- * Author        :   FrankieChu 
+ * Author        :   FrankieChu
  * Create Time   :   Jan 2013
  * Change Log    :
  *
@@ -27,7 +27,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 #include <Wire.h>
 #include "MMA7660.h"
 /*Function: Write a byte to the register of the MMA7660*/
@@ -35,7 +35,7 @@ void MMA7660::write(uint8_t _register, uint8_t _data)
 {
     Wire.begin();
     Wire.beginTransmission(MMA7660_ADDR);
-    Wire.write(_register);   
+    Wire.write(_register);
     Wire.write(_data);
     Wire.endTransmission();
 }
@@ -45,7 +45,7 @@ uint8_t MMA7660::read(uint8_t _register)
     uint8_t data_read;
     Wire.begin();
     Wire.beginTransmission(MMA7660_ADDR);
-    Wire.write(_register); 
+    Wire.write(_register);
     Wire.endTransmission();
     Wire.beginTransmission(MMA7660_ADDR);
     Wire.requestFrom(MMA7660_ADDR,1);
@@ -61,6 +61,8 @@ void MMA7660::init()
 {
     setMode(MMA7660_STAND_BY);
     setSampleRate(AUTO_SLEEP_32);
+    write(MMA7660_INTSU, 0xE0);
+    write(MMA7660_PDET, 0xE0);
     setMode(MMA7660_ACTIVE);
 }
 void MMA7660::setMode(uint8_t mode)
@@ -81,11 +83,11 @@ void MMA7660::getXYZ(int8_t *x,int8_t *y,int8_t *z)
     while(Wire.available() > 0)
         Wire.read();
     Wire.requestFrom(MMA7660_ADDR,3);
-    while(Wire.available())  
+    while(Wire.available())
     {
         if(count < 3)
         {
-            while ( val[count] > 63 )  // reload the damn thing it is bad
+            while ( val[count] > 0x3F )  // reload the damn thing it is bad
             {
               val[count] = Wire.read();
             }
@@ -97,6 +99,31 @@ void MMA7660::getXYZ(int8_t *x,int8_t *y,int8_t *z)
     *z = ((char)(val[2]<<2))/4;
 }
 
+void MMA7660::getData()
+{
+  unsigned char val[11] = {0};
+  int count = 0;
+
+  while(Wire.available() > 0)
+      Wire.read();
+  Wire.requestFrom(MMA7660_ADDR,11);
+  while(Wire.available())
+  {
+      if(count < 11)
+      {
+        val[count] = Wire.read();
+      }
+      count++;
+  }
+
+  for (count = 0; count < 11; count++) {
+    Serial.printf("0x%02X val: 0x%02X\n", count, val[count]);
+  }
+
+  Serial.printf("Shake sensor: 0x%02X\n", val[3] & 0x80);
+  Serial.printf("Tap sensor: 0x%02X\n", val[3] & 0x20);
+}
+
 void MMA7660::getAcceleration(float *ax,float *ay,float *az)
 {
     int8_t x,y,z;
@@ -105,4 +132,3 @@ void MMA7660::getAcceleration(float *ax,float *ay,float *az)
     *ay = y/21.00;
     *az = z/21.00;
 }
-

--- a/MMA7660.h
+++ b/MMA7660.h
@@ -63,7 +63,7 @@
 #define MMA7660_PDET  0x09
 #define MMA7660_PD    0x0A
 
-struct MMA7760_DATA {
+struct MMA7660_DATA {
   uint8_t X;
   uint8_t Y;
   uint8_t Z;
@@ -77,18 +77,33 @@ struct MMA7760_DATA {
   uint8_t PD;
 };
 
+struct MMA7660_LOOKUP {
+  float g;
+  float xyAngle;
+  float zAngle;
+};
+
+struct MMA7660_ACC_DATA {
+  MMA7660_LOOKUP x;
+  MMA7660_LOOKUP y;
+  MMA7660_LOOKUP z;
+};
+
 class MMA7660 {
 private:
   void write(uint8_t _register, uint8_t _data);
   uint8_t read(uint8_t _register);
+  void initAccelTable();
+
+  MMA7660_LOOKUP accLookup[64];
+  
 public:
   void init();
   void init(uint8_t interrupts);
   void setMode(uint8_t mode);
   void setSampleRate(uint8_t rate);
-  void getXYZ(int8_t *x, int8_t *y, int8_t *z);
-  void getAllData(MMA7760_DATA *data);
-  void getAcceleration(float *ax,float *ay,float *az);
+  void getXYZ(MMA7660_ACC_DATA *data);
+  void getAllData(MMA7660_DATA *data);
 };
 
 #endif

--- a/MMA7660.h
+++ b/MMA7660.h
@@ -40,32 +40,55 @@
 #define MMA7660_SRST  0x04
 #define MMA7660_SPCNT 0x05
 #define MMA7660_INTSU 0x06
+  #define MMA7660_SHINTX 0x80
+  #define MMA7660_SHINTY 0x40
+  #define MMA7660_SHINTZ 0x20
+  #define MMA7660_GINT 0x10
+  #define MMA7660_ASINT 0x08
+  #define MMA7660_PDINT 0x04
+  #define MMA7660_PLINT 0x02
+  #define MMA7660_FBINT 0x01
 #define MMA7660_MODE  0x07
-    #define MMA7660_STAND_BY 0x00
-    #define MMA7660_ACTIVE   0x01
+  #define MMA7660_STAND_BY 0x00
+  #define MMA7660_ACTIVE   0x01
 #define MMA7660_SR    0x08      //sample rate register
-    #define AUTO_SLEEP_120  0X00//120 sample per second
-    #define AUTO_SLEEP_64   0X01
-    #define AUTO_SLEEP_32   0X02
-    #define AUTO_SLEEP_16   0X03
-    #define AUTO_SLEEP_8    0X04
-    #define AUTO_SLEEP_4    0X05
-    #define AUTO_SLEEP_2    0X06
-    #define AUTO_SLEEP_1    0X07
+  #define AUTO_SLEEP_120  0X00//120 sample per second
+  #define AUTO_SLEEP_64   0X01
+  #define AUTO_SLEEP_32   0X02
+  #define AUTO_SLEEP_16   0X03
+  #define AUTO_SLEEP_8    0X04
+  #define AUTO_SLEEP_4    0X05
+  #define AUTO_SLEEP_2    0X06
+  #define AUTO_SLEEP_1    0X07
 #define MMA7660_PDET  0x09
 #define MMA7660_PD    0x0A
-class MMA7660
-{
+
+struct MMA7760_DATA {
+  uint8_t X;
+  uint8_t Y;
+  uint8_t Z;
+  uint8_t TILT;
+  uint8_t SRST;
+  uint8_t SPCNT;
+  uint8_t INTSU;
+  uint8_t MODE;
+  uint8_t SR;
+  uint8_t PDET;
+  uint8_t PD;
+};
+
+class MMA7660 {
 private:
+  void write(uint8_t _register, uint8_t _data);
+  uint8_t read(uint8_t _register);
 public:
-    void init();
-    void write(uint8_t _register, uint8_t _data);
-    uint8_t read(uint8_t _register);
-    void setMode(uint8_t mode);
-    void setSampleRate(uint8_t rate);
-    void getXYZ(int8_t *x,int8_t *y,int8_t *z);
-    void getData();
-    void getAcceleration(float *ax,float *ay,float *az);
+  void init();
+  void init(uint8_t interrupts);
+  void setMode(uint8_t mode);
+  void setSampleRate(uint8_t rate);
+  void getXYZ(int8_t *x, int8_t *y, int8_t *z);
+  void getAllData(MMA7760_DATA *data);
+  void getAcceleration(float *ax,float *ay,float *az);
 };
 
 #endif

--- a/MMA7660.h
+++ b/MMA7660.h
@@ -3,7 +3,7 @@
  * Library for accelerometer_MMA7760
  *
  * Copyright (c) 2013 seeed technology inc.
- * Author        :   FrankieChu 
+ * Author        :   FrankieChu
  * Create Time   :   Jan 2013
  * Change Log    :
  *
@@ -27,7 +27,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 #ifndef __MMC7660_H__
 #define __MMC7660_H__
 
@@ -42,7 +42,7 @@
 #define MMA7660_INTSU 0x06
 #define MMA7660_MODE  0x07
     #define MMA7660_STAND_BY 0x00
-    #define MMA7660_ACTIVE   0x01   
+    #define MMA7660_ACTIVE   0x01
 #define MMA7660_SR    0x08      //sample rate register
     #define AUTO_SLEEP_120  0X00//120 sample per second
     #define AUTO_SLEEP_64   0X01
@@ -57,16 +57,15 @@
 class MMA7660
 {
 private:
-    void write(uint8_t _register, uint8_t _data);
-    uint8_t read(uint8_t _register);
 public:
     void init();
+    void write(uint8_t _register, uint8_t _data);
+    uint8_t read(uint8_t _register);
     void setMode(uint8_t mode);
     void setSampleRate(uint8_t rate);
     void getXYZ(int8_t *x,int8_t *y,int8_t *z);
+    void getData();
     void getAcceleration(float *ax,float *ay,float *az);
 };
 
 #endif
-
-


### PR DESCRIPTION
I added a method which populates the lookup table in the MMA7660 datasheet on page 28/29, which can be found here: http://www.farnell.com/datasheets/1670762. I eliminated the getAcceleration function as it was returning an arbitrary calculation on the XYZ registers, not the acceleration data. 

the getXYZ method now returns both the acceleration data AND the tilt angles. However according to the datasheet, you can only pay attention to the tilt angles if the acceleration is less than 1g. 

Additionally I added a new constructer which allows you to subscribe to the interrupts.